### PR TITLE
Externalize CSS and JS and defer main.js

### DIFF
--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -12,10 +12,10 @@
 			{{ site.title or renderData.title or title or metadata.title }}
 		</title>
 		<link rel="stylesheet" href="{% webpackAsset 'main.css' %}" />
+		<script defer src="{% webpackAsset 'main.js' %}"></script>
 	</head>
 
 	<body>
 		{{ content }}
-		<script src="{% webpackAsset 'main.js' %}"></script>
 	</body>
 </html>


### PR DESCRIPTION
Sticking to externalizing CSS and JS for now. This might cause a tiny
delay on initial page load, but increases repeat visit performance a
lot since CSS and JS don't have to be re-downloaded.

Main.js depends on the DOM being loaded. With `defer` the script can be
discovered and downloaded earlier than when it's placed just before the
`</body>` tag. It will not block HTML rendering, but will be executed
after HTML parsing is done.

See https://bitsofco.de/async-vs-defer/ for details on defer vs async.

Fixes #13.