### PR TITLE
Strip query parameters from filenames in webpack manifest

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -97,7 +97,12 @@ module.exports = {
 			ignoreOrder: false
 		}),
 		new ManifestPlugin({
-			fileName: "../src/_includes/.webpack/manifest.json"
+			fileName: "../src/_includes/.webpack/manifest.json",
+			map: file => {
+				// Strip queries like ?external from asset name
+				file.name = file.name.split("?")[0];
+				return file;
+			}
 		})
 	]
 };


### PR DESCRIPTION
Before if you would import an asset with a query parameter, it would
become part of the key in the manifest:

Import:

```js
import "./some/file.svg?external"
```

Manifest:

```json
{
	"file.svg?external": "./file.HASH.svg"
}
```

Which is annoying because it means you need to specify the query as well
in order to use the file:

```html
<img src="{{ webpackAsset 'file.svg?external' }}" />
```

Now, the query is stripped from the manifest so you can simply refer to
the filename:

```html
<img src="{{ webpackAsset 'file.svg' }}" />
```