### PR TITLE
URL encode inline svg images

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
 		"stylelint-config-prettier": "^7.0.0",
 		"stylelint-config-standard": "^19.0.0",
 		"stylelint-no-unsupported-browser-features": "^4.0.0",
+		"svg-url-loader": "^3.0.3",
 		"url-loader": "^3.0.0",
 		"webpack": "^4.41.2",
 		"webpack-cli": "^3.3.10",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -7,6 +7,8 @@ const isProd = env === "production";
 const out = path.resolve(__dirname, "_site");
 const exclusions = /node_modules/;
 
+const inlineImgLimit = 8192;
+
 const optimization = {
 	splitChunks: isProd && { chunks: "all" },
 	minimize: isProd,
@@ -63,7 +65,29 @@ module.exports = {
 				]
 			},
 			{
-				test: /\.(png|jpg|svg)$/i,
+				test: /\.svg$/i,
+				oneOf: [
+					{
+						resourceQuery: /external/,
+						loader: "file-loader",
+						options: fileLoaderOptions
+					},
+					{
+						resourceQuery: /inline/,
+						loader: "svg-url-loader",
+						options: fileLoaderOptions
+					},
+					{
+						loader: "svg-url-loader",
+						options: {
+							...fileLoaderOptions,
+							limit: inlineImgLimit
+						}
+					}
+				]
+			},
+			{
+				test: /\.(png|jpg)$/i,
 				oneOf: [
 					{
 						resourceQuery: /external/,
@@ -74,15 +98,15 @@ module.exports = {
 						resourceQuery: /inline/,
 						loader: "url-loader",
 						options: {
-							limit: true,
-							...fileLoaderOptions
+							...fileLoaderOptions,
+							limit: true
 						}
 					},
 					{
 						loader: "url-loader",
 						options: {
-							limit: 8192,
-							...fileLoaderOptions
+							...fileLoaderOptions,
+							limit: inlineImgLimit
 						}
 					}
 				]

--- a/yarn.lock
+++ b/yarn.lock
@@ -3695,6 +3695,14 @@ file-loader@^5.0.2:
     loader-utils "^1.2.3"
     schema-utils "^2.5.0"
 
+file-loader@~4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/file-loader/-/file-loader-4.3.0.tgz#780f040f729b3d18019f20605f723e844b8a58af"
+  integrity sha512-aKrYPYjF1yG3oX0kWRrqrSMfgftm7oJW5M+m4owoldH5C51C0RkIwB++JbRvEW3IU6/ZG5n8UvEcdgwOt2UOWA==
+  dependencies:
+    loader-utils "^1.2.3"
+    schema-utils "^2.5.0"
+
 filing-cabinet@^2.3.1:
   version "2.5.0"
   resolved "https://registry.yarnpkg.com/filing-cabinet/-/filing-cabinet-2.5.0.tgz#325ac8acf6932597d589ef6bc37239fe57b8bc70"
@@ -5310,7 +5318,7 @@ loader-runner@^2.4.0:
   resolved "https://registry.yarnpkg.com/loader-runner/-/loader-runner-2.4.0.tgz#ed47066bfe534d7e84c4c7b9998c2a75607d9357"
   integrity sha512-Jsmr89RcXGIwivFY21FcRrisYZfvLMTWx5kOLc+JTxtpBOG6xML0vzbc6SEQG2FO9/4Fc3wW4LVcB5DmGflaRw==
 
-loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3:
+loader-utils@1.2.3, loader-utils@^1.0.2, loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@~1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/loader-utils/-/loader-utils-1.2.3.tgz#1ff5dc6911c9f0a062531a4c04b609406108c2c7"
   integrity sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==
@@ -8884,6 +8892,14 @@ svg-tags@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/svg-tags/-/svg-tags-1.0.0.tgz#58f71cee3bd519b59d4b2a843b6c7de64ac04764"
   integrity sha1-WPcc7jvVGbWdSyqEO2x95krAR2Q=
+
+svg-url-loader@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/svg-url-loader/-/svg-url-loader-3.0.3.tgz#95274eae80f4a46454a5b44e9582beb2f533465e"
+  integrity sha512-MKGiRNDs8fnHcZcPkhGcw9+130IXyFM9H8m6T7u3ScUuZYEeVzX0vNMru30D4MCF6vMYas5iw/Ru9lwFKBjaGw==
+  dependencies:
+    file-loader "~4.3.0"
+    loader-utils "~1.2.3"
 
 svgo@^1.0.0:
   version "1.3.2"


### PR DESCRIPTION
Instead of base64 encoding.

From https://github.com/bhovhannes/svg-url-loader:

> There are some benefits for choosing utf-8 encoding over base64.
>
> Resulting string is shorter (can be ~2 times shorter for 2K-sized icons);
> Resulting string will be compressed better when using gzip compression;
> Browser parses utf-8 encoded string faster than its base64 equivalent.

Behaves like other assets with respect to inlining/extracting:
* Automatically inlined if size is <= 8kb
* Force inline with `?inline`
* Force external with `?external`