### PR TITLE
Run eslint in pre commit hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
 			"prettier --write",
 			"git add"
 		],
+		"*.js": [
+			"eslint"
+		],
 		"*.css": [
 			"stylelint"
 		]


### PR DESCRIPTION
Fixes #29.

@RoelN there was already a hook to run stylelint on pre commit, but not eslint. I've added this now.