### PR TITLE
Workaround/yarn bug causing incorrect version of specimen-boilerplate-support

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
 		"postcss-loader": "^3.0.0",
 		"prettier": "^1.19.1",
 		"rimraf": "^3.0.0",
-		"specimen-boilerplate-support": "kabisa/specimen-boilerplate-support#master",
+		"specimen-boilerplate-support": "https://github.com/kabisa/specimen-boilerplate-support.git#master",
 		"stylelint": "^12.0.0",
 		"stylelint-config-prettier": "^7.0.0",
 		"stylelint-config-standard": "^19.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8527,9 +8527,9 @@ specificity@^0.4.1:
   resolved "https://registry.yarnpkg.com/specificity/-/specificity-0.4.1.tgz#aab5e645012db08ba182e151165738d00887b019"
   integrity sha512-1klA3Gi5PD1Wv9Q0wUoOQN1IWAuPu0D1U03ThXTr0cJ20+/iq2tHSDnK7Kk/0LXJ1ztUB2/1Os0wKmfyNgUQfg==
 
-specimen-boilerplate-support@kabisa/specimen-boilerplate-support#master:
+"specimen-boilerplate-support@https://github.com/kabisa/specimen-boilerplate-support.git#master":
   version "1.0.0"
-  resolved "https://codeload.github.com/kabisa/specimen-boilerplate-support/tar.gz/63b62a4b5a6da0545f85e5286c0ef909978877b7"
+  resolved "https://github.com/kabisa/specimen-boilerplate-support.git#63b62a4b5a6da0545f85e5286c0ef909978877b7"
   dependencies:
     fontkit "^1.8.0"
     postcss "^7.0.25"


### PR DESCRIPTION
See yarnpkg/yarn#4722 and specifically
yarnpkg/yarn#4722 (comment).

The issue does not occur when specifying the dependency as
https://github.com/user/repo.git#BRANCH.

