### PR TITLE
Only take woff2 files into account for generating fontdata

### DIFF
--- a/_tools/generateFontData.js
+++ b/_tools/generateFontData.js
@@ -55,7 +55,9 @@ const writeFontJs = async fontData => {
 };
 
 const findFirstFontFile = async directory => {
-	const fontFiles = await util.promisify(fs.readdir)(directory);
+	const fontFiles = (await util.promisify(fs.readdir)(directory)).filter(
+		f => path.extname(f) == ".woff2"
+	);
 
 	assert(
 		fontFiles.length > 0,


### PR DESCRIPTION
Fixes https://github.com/kabisa/specimen-boilerplate-support/issues/4